### PR TITLE
Add permissive CORS headers to handle resolution endpoint

### DIFF
--- a/app/[domain]/[handle]/.well-known/atproto-did/route.ts
+++ b/app/[domain]/[handle]/.well-known/atproto-did/route.ts
@@ -2,6 +2,19 @@ import { type NextRequest } from "next/server"
 
 import { prisma } from "@/lib/db"
 
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "GET, OPTIONS",
+  "Access-Control-Allow-Headers": "*",
+}
+
+export const OPTIONS = async () => {
+  return new Response(null, {
+    status: 204,
+    headers: corsHeaders,
+  })
+}
+
 export const GET = async (
   _req: NextRequest,
   { params }: { params: { domain: string; handle: string } }
@@ -12,6 +25,7 @@ export const GET = async (
   return new Response(did, {
     headers: {
       "content-type": "text/plain",
+      ...corsHeaders,
     },
   })
 }


### PR DESCRIPTION
Allow cross-origin requests to the .well-known/atproto-did endpoint
by adding Access-Control-Allow-Origin: * and supporting OPTIONS
preflight requests.